### PR TITLE
Tools that expose the SDK docs through a tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN bash -ex /app/fetch-docs.sh
 ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
+RUN cp -r /app/resources /opt/groundlight/docs/resources
 
 
 FROM python:3.11-slim-bookworm

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,11 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 RUN ls -la /app/.venv/bin
 
+RUN apt update && apt install -y \
+    git
+
+RUN mkdir /opt/groundlight
+COPY fetch-docs.sh /app/fetch-docs.sh
+RUN bash -ex /app/fetch-docs.sh
+
 ENTRYPOINT ["groundlight-mcp-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim AS uv
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm AS uv
 
 WORKDIR /app
 
@@ -11,6 +11,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-install-project --no-dev --no-editable
 
+# fetch docs before adding the rest of the source code
+RUN mkdir /opt/groundlight
+COPY fetch-docs.sh /app/fetch-docs.sh
+RUN bash -ex /app/fetch-docs.sh
+
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
 ADD . /app
@@ -20,19 +25,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM python:3.11-slim-bookworm
 
+
 WORKDIR /app
 
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
+COPY --from=uv --chown=app:app /opt/groundlight /opt/groundlight
 
 ENV PATH="/app/.venv/bin:$PATH"
 
 RUN ls -la /app/.venv/bin
-
-RUN apt update && apt install -y \
-    git
-
-RUN mkdir /opt/groundlight
-COPY fetch-docs.sh /app/fetch-docs.sh
-RUN bash -ex /app/fetch-docs.sh
 
 ENTRYPOINT ["groundlight-mcp-server"]

--- a/fetch-docs.sh
+++ b/fetch-docs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+cd /opt/groundlight/
+mkdir -p docs/sdk
+mkdir -p src
+
+cd src
+if [ -d python-sdk ]; then
+    cd python-sdk
+    git pull
+    cd ..
+else
+    git clone --depth 1 --filter=blob:none \
+    https://github.com/groundlight/python-sdk
+fi
+cd python-sdk/docs
+cp -r docs/* /opt/groundlight/docs/sdk
+
+

--- a/resources/groundlight=applications/Building-Groundlight-Applications.md
+++ b/resources/groundlight=applications/Building-Groundlight-Applications.md
@@ -43,9 +43,11 @@ A simple or demo groundlight application typically consists of a single binary o
 
 Demo applications should include plenty of print statements, and use the imgcat library to preview images as they're fetched.
 
+For demo applications, a relatively low confidence threshold like 0.75 is fine and makes for a better demo.
+
 ### Advanced Applications
 
-An "advanced" groundlight application typically consists of a 3-detector pipeline:
+An "advanced" or "production" groundlight application typically consists of a 3-detector pipeline:
 
 - Binary classification: Does the image have something that deserves a closer look?
 - Counting: Find the objects of interest within the image.  Zoom in on them.
@@ -54,6 +56,8 @@ An "advanced" groundlight application typically consists of a 3-detector pipelin
 The first detector is typically run in "high recall" mode, where UNCLEAR's are treated like YES and passed to the next stage.  OD models don't have as straightforward control over precision/recall.
 
 Simple or demonstration tasks can be accomplished with a single binary or multiclass detector.  But the 3-detector pipeline is the most reliable.
+
+Production applications' detectors should have a relatively high confidence threshold like 0.9 by default.
 
 ## Practicalities
 
@@ -182,7 +186,7 @@ class SimpleApp():
             self.last_motion_post = time.time()
             rgb_img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
             imgcat(rgb_img)
-            img_query = self.gl.ask_ml(detector=self.detector, image=big_img)
+            img_query = self.gl.ask_confident(detector=self.detector, image=big_img)
             if img_query.result.label == "YES":
                 print(f"YES at {now} iqid={img_query.id}")
                 self.last_state = "YES"

--- a/resources/groundlight=applications/Building-Groundlight-Applications.md
+++ b/resources/groundlight=applications/Building-Groundlight-Applications.md
@@ -1,0 +1,55 @@
+# How to Build a Groundlight Application
+
+Groundlight applications are Agentic processes that monitor video streams in the background for you, to monitor for specified events or conditions.  
+
+## Architecture
+
+The components to a full system are:
+- A camera
+- The Groundlight application code
+- The Groundlight edge inference server (optional)
+- The Groundlight cloud service
+
+Cameras are typically networked cameras, but could be local USB cameras.  Applications use the `framegrab` library to abstract the camera interface, so that the same code can be used for local cameras, streaming cameras, and cameras behind NVRs.  The only difference is in the `cameras.yaml` configuration file, which defines the camera sources.  When using a managed Groundlight Hub device, the hub will provide the `cameras.yaml` file for the application, using its built-in camera-discovery UI.  But for development purposes, authoring a short stand-alone `cameras.yaml` file is appropriate.
+
+The application code typically run on an edge device, near the camera, but might execute directly on a smart camera, or could run in the cloud if the full video stream is already streamed there through an advanced NVR system.  For high frame rate video (>1fps) the application should be configured to run the detectors locally using an [edge-endpoit](https://github.com/groundlight/edge-endpoint) server.  (This is recommended for any framerate higher than 1 frame/minute).
+The edge-endoint server is an open-source service that acts identically to the cloud API as far as the SDK is concerned.  So the same application code can be used for local development, and for the deployed application - the only difference is changing the `GROUNDLIGHT_ENDPOINT` environment variable to point to the local server (e.g. `http://localhost:30101`) instead of its default value of `https://api.groundlight.ai`.
+
+## Detector setup
+
+Groundlight detectors can perform simple computer-vision tasks reliably, using a combination of fast local models, powerful cloud models, and live human oversight.  Every Groundlight detector responds to inference requests with both a prediction and a confidence score.  If the confidence score is below a configurable threshold, the default behavior is to escalate the image to the next level for more careful analysis, although this behavior can be overridden.  (See `ask_async` vs `ask_ml` vs `ask_confident` in the SDK guide page `submitting-image-queries`)
+
+Groundlight detectors can be of the following types:
+- Binary classification: Answer YES / UNCLEAR / NO.  These are the most reliable and easy to understand detectors.
+- Multiclass classification: Answer one of K classes.  (Best with k <= 6)
+- Counting: Count the number of objects in an image.  Also returns their locations as bounding boxes.
+
+Some but not all accounts also have access to the following types:
+- Text recognition: Detect and transcribe text in an image.
+- Object detection: Detect and localize multiple objects in an image.  (Functionally similar to counting, but optimizes quality for bounding boxes, not the correct count.  Cannot distinguishi different classes of objects.)
+
+Note that counting and object-detection models (collectively "OD" models) cost about 10x more than the binary-classification models for inference.  As such a typical inference pipeline consists of three detectors:
+
+- Binary classification: Does the image have something that deserves a closer look?
+- Counting: Find the objects of interest within the image.  Zoom in on them.
+- Multiclass classification: Looking at the zoomed-in object, is it actually doing what we're interested in?  Or was there a false positive initially?  Also differentiate between different kinds of objects / activities of interest.
+
+The first detector is typically run in "high recall" mode, where UNCLEAR's are treated like YES and passed to the next stage.  OD models don't have as straightforward control over precision/recall.
+
+Simple tasks can be accomplished with a single binary or multiclass detector.  But the 3-detector pipeline is the most reliable.
+
+## Practicalities
+
+Configure a grabber object using the `framegrab` library from the cameras.yaml file.  If you're authoring a full demo, author this file as well.  Leave secrets like RTSP login credentials.
+
+Assume the `GROUNDLIGHT_API_TOKEN` and `GROUNDLIGHT_ENDPOINT` environment variables are already set when the application starts.  Simply instantiating the Groundlight SDK client will use these automatically - no need to configure them in code.
+
+
+
+
+
+
+
+
+
+

--- a/resources/groundlight=applications/Building-Groundlight-Applications.md
+++ b/resources/groundlight=applications/Building-Groundlight-Applications.md
@@ -28,7 +28,15 @@ Some but not all accounts also have access to the following types:
 - Text recognition: Detect and transcribe text in an image.
 - Object detection: Detect and localize multiple objects in an image.  (Functionally similar to counting, but optimizes quality for bounding boxes, not the correct count.  Cannot distinguishi different classes of objects.)
 
-Note that counting and object-detection models (collectively "OD" models) cost about 10x more than the binary-classification models for inference.  As such a typical inference pipeline consists of three detectors:
+Note that counting and object-detection models (collectively "OD" models) cost about 10x more than the binary-classification models for inference.  
+
+### Simple Applications
+
+A "simple" groundlight application typically consists of a single binary or multiclass detector.  These are the most reliable and easy to understand detectors.  For quick demos, these are a great choice.
+
+### Advanced Applications
+
+An "advanced" groundlight application typically consists of a 3-detector pipeline:
 
 - Binary classification: Does the image have something that deserves a closer look?
 - Counting: Find the objects of interest within the image.  Zoom in on them.
@@ -40,7 +48,7 @@ Simple tasks can be accomplished with a single binary or multiclass detector.  B
 
 ## Practicalities
 
-Configure a grabber object using the `framegrab` library from the cameras.yaml file.  If you're authoring a full demo, author this file as well.  Leave secrets like RTSP login credentials.
+Configure a grabber object using the `framegrab` library from the cameras.yaml file.  If you're authoring a full demo, author this file as well.  Leave secrets like RTSP login credentials.  In most cases, the grabber should be configured with simple motion detection, to reduce inference workloads when the scene is still.
 
 Assume the `GROUNDLIGHT_API_TOKEN` and `GROUNDLIGHT_ENDPOINT` environment variables are already set when the application starts.  Simply instantiating the Groundlight SDK client will use these automatically - no need to configure them in code.
 

--- a/resources/groundlight=applications/Building-Groundlight-Applications.md
+++ b/resources/groundlight=applications/Building-Groundlight-Applications.md
@@ -7,6 +7,7 @@ Groundlight applications are Agentic processes that monitor video streams in the
 The components to a full system are:
 - A camera
 - The Groundlight application code
+- The Groundlight Detectors (CV / ML models)
 - The Groundlight edge inference server (optional)
 - The Groundlight cloud service
 
@@ -30,9 +31,17 @@ Some but not all accounts also have access to the following types:
 
 Note that counting and object-detection models (collectively "OD" models) cost about 10x more than the binary-classification models for inference.  
 
-### Simple Applications
+When an AI agent is building a groundlight application, it should create the detectors using the MCP server capabilities, instead of writing code to call the Groundlight API to configure the detectors.
 
-A "simple" groundlight application typically consists of a single binary or multiclass detector.  These are the most reliable and easy to understand detectors.  For quick demos, these are a great choice.
+## Coding the Applications
+
+Applications are coded in python, and run from the command line without arguments.
+
+### Demo Applications
+
+A simple or demo groundlight application typically consists of a single binary or multiclass detector.  These are the most reliable and easy to understand detectors.  For quick demos, these are a great choice.
+
+Demo applications should include plenty of print statements, and use the imgcat library to preview images as they're fetched.
 
 ### Advanced Applications
 
@@ -44,11 +53,33 @@ An "advanced" groundlight application typically consists of a 3-detector pipelin
 
 The first detector is typically run in "high recall" mode, where UNCLEAR's are treated like YES and passed to the next stage.  OD models don't have as straightforward control over precision/recall.
 
-Simple tasks can be accomplished with a single binary or multiclass detector.  But the 3-detector pipeline is the most reliable.
+Simple or demonstration tasks can be accomplished with a single binary or multiclass detector.  But the 3-detector pipeline is the most reliable.
 
 ## Practicalities
 
 Configure a grabber object using the `framegrab` library from the cameras.yaml file.  If you're authoring a full demo, author this file as well.  Leave secrets like RTSP login credentials.  In most cases, the grabber should be configured with simple motion detection, to reduce inference workloads when the scene is still.
+
+For demo purposes, this is a super-generic cameras.yaml that will probably "just work" for a laptop's built-in webcam:
+
+```
+image_sources:
+- input_type: generic_usb
+  name: generic_usb_unnamed_0
+  options: {}
+  serial_number: null
+```
+
+Customers should be advised they can create their own by running:
+
+```
+framegrab autodiscover --preview none > cameras.yaml
+```
+
+and then test it / iterate with
+
+```
+framegrab preview cameras.yaml
+```
 
 Assume the `GROUNDLIGHT_API_TOKEN` and `GROUNDLIGHT_ENDPOINT` environment variables are already set when the application starts.  Simply instantiating the Groundlight SDK client will use these automatically - no need to configure them in code.
 
@@ -56,8 +87,113 @@ Assume the `GROUNDLIGHT_API_TOKEN` and `GROUNDLIGHT_ENDPOINT` environment variab
 
 
 
+# Sample code
+
+## Demonstration app with Voice Alert.
+
+Here is an example of a complete demonstration app, which plays a voice alert when the detector
+state changes from YES to NO.  Note the detector_id is hard-coded into the application. 
+This is because the Agent should use the Groundlight MCP server to create the detector before authoring the app code.
 
 
+```
+#!/usr/bin/env python3
+import os
+import time
+import traceback
+import tempfile
+import platform
+
+from groundlight import Groundlight
+from imgcat import imgcat
+import cv2
+import framegrab
+from gtts import gTTS
 
 
+class VoiceAlerts():
+    """Plays sounds of a TTS voice reading messages.
+    """
+
+    def __init__(self, message:str="voice alert"):
+        self.message = message
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.sound_path = os.path.join(self.temp_dir.name, "alert.mp3")
+        self._generate_sound()
+        self.player = "afplay" if platform.system() == "Darwin" else "mpg321"
+
+    def _generate_sound(self):
+        """Generates the TTS sound file from the message."""
+        tts = gTTS(text=self.message, lang='en')
+        tts.save(self.sound_path)
+
+    def alert(self):
+        """Plays a sound."""
+        print(f"Playing voice alert: {self.message}")
+        os.system(f"{self.player} {self.sound_path}")
+
+    def __del__(self):
+        """Clean up the temporary directory."""
+        self.temp_dir.cleanup()
+
+
+class SimpleApp():
+    """A simple detector app which plays a voice alert that says "You did the thing!"
+    When the detector changes from YES state to NO state.
+    """
+
+    def __init__(self):
+        all_cameras = framegrab.FrameGrabber.from_yaml("./cameras.yaml")
+        self.camera = all_cameras[0]  # Use the first camera
+        self.motdet = framegrab.MotionDetector(pct_threshold=0.5, val_threshold=50)
+        self.gl = Groundlight()
+        detector_id = os.environ.get("DETECTOR_ID", "det_2x8hkwPnOp8EGJLgZBdCF54I2ez")
+        self.detector = self.gl.get_detector(detector_id)
+        print(f"Using {self.detector}")
+        # Timing constants
+        self.exception_backoff_s = 60
+        self.motion_interval_s = 2
+        self.no_motion_post_anyway_s = 7200
+        self.last_motion_post = time.time() - self.no_motion_post_anyway_s
+        self.noisy = VoiceAlerts(message="You did the thing!")
+
+        self.last_state = "?"
+
+    def run(self):
+
+        while True:
+            try:
+                self.process_frame()
+            except Exception as e:
+                traceback.print_exc()
+                time.sleep(self.exception_backoff_s)
+    
+    def process_frame(self):
+        now = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
+        big_img = self.camera.grab()  # big_img is a numpy array
+        img = cv2.resize(big_img, (800, 600))  # smaller for preview and motdet
+        motion_detected = self.motdet.motion_detected(img)
+        if not motion_detected:
+            print(f"no motion at {now}")
+            if time.time() - self.last_motion_post > self.no_motion_post_anyway_s:
+                print(f"No motion detected for {self.no_motion_post_anyway_s}s, posting anyway")
+                motion_detected = True
+        if motion_detected:
+            self.last_motion_post = time.time()
+            rgb_img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            imgcat(rgb_img)
+            img_query = self.gl.ask_ml(detector=self.detector, image=big_img)
+            if img_query.result.label == "YES":
+                print(f"YES at {now} iqid={img_query.id}")
+                self.last_state = "YES"
+            elif img_query.result.label == "NO":
+                print(f"NO at {now} iqid={img_query.id}")
+                if self.last_state == "YES":
+                    self.noisy.alert()
+                self.last_state = "NO"
+        time.sleep(self.motion_interval_s)
+
+if __name__ == "__main__":
+    SimpleApp().run()
+```
 

--- a/src/groundlight_mcp_server/server.py
+++ b/src/groundlight_mcp_server/server.py
@@ -2,6 +2,7 @@ import logging
 from contextlib import asynccontextmanager
 from functools import cache
 from typing import Annotated, Any, Dict, List, Literal, Optional
+from pathlib import Path
 
 from groundlight import (
     ROI,
@@ -13,6 +14,7 @@ from groundlight import (
     VerbEnum,
 )
 from mcp.server.fastmcp import FastMCP, Image
+from mcp.server.fastmcp.resources import Resource
 from pydantic import BaseModel, Field
 
 from groundlight_mcp_server.utils import load_image, render_bounding_boxes, to_mcp_image
@@ -440,7 +442,7 @@ async def list_docs() -> list[Resource]:
     
     return resources
 
-@mcp.resource("docs://{path:path}")
+@mcp.resource("docs://{path}")
 async def read_doc(path: str) -> str:
     """Read a specific documentation file"""
     file_path = DOCS_DIR / path

--- a/src/groundlight_mcp_server/server.py
+++ b/src/groundlight_mcp_server/server.py
@@ -419,7 +419,7 @@ def update_detector_escalation_type(
 # Documentation directory
 DOCS_DIR = Path("/opt/groundlight/docs/")
 
-@mcp.resource("docs://list")
+@mcp.resource("file:///list")
 async def list_docs() -> list[Resource]:
     """List all available documentation resources"""
     resources = []
@@ -428,7 +428,7 @@ async def list_docs() -> list[Resource]:
     for file_path in DOCS_DIR.rglob("*.md"):
         # Create relative path for cleaner URIs
         relative_path = file_path.relative_to(DOCS_DIR)
-        uri = f"docs://{relative_path.as_posix()}"
+        uri = f"{relative_path.as_posix()}"
         
         # Extract a friendly name from the filename
         name = file_path.stem.replace("-", " ").replace("_", " ").title()
@@ -442,7 +442,7 @@ async def list_docs() -> list[Resource]:
     
     return resources
 
-@mcp.resource("docs://{path}")
+@mcp.resource("{path}")
 async def read_doc(path: str) -> str:
     """Read a specific documentation file"""
     file_path = DOCS_DIR / path
@@ -461,12 +461,12 @@ async def read_doc(path: str) -> str:
     else:
         raise ValueError(f"Documentation not found: {path}")
 
-@mcp.resource("docs://index")
+@mcp.resource("file:///index")
 async def docs_index() -> str:
     """Get an index of all available documentation"""
     docs = []
     for file_path in sorted(DOCS_DIR.rglob("*.md")):
         relative_path = file_path.relative_to(DOCS_DIR)
-        docs.append(f"- [{file_path.stem}](docs://{relative_path.as_posix()})")
+        docs.append(f"- [{file_path.stem}]({relative_path.as_posix()})")
 
     return "# Groundlight Documentation Index\n\n" + "\n".join(docs)

--- a/src/groundlight_mcp_server/server.py
+++ b/src/groundlight_mcp_server/server.py
@@ -419,31 +419,27 @@ def update_detector_escalation_type(
 # Documentation directory
 DOCS_DIR = Path("/opt/groundlight/docs/")
 
-@mcp.resource("file:///list")
-async def list_docs() -> list[Resource]:
-    """List all available documentation resources"""
-    resources = []
-    
-    # Walk through the docs directory
-    for file_path in DOCS_DIR.rglob("*.md"):
-        # Create relative path for cleaner URIs
+@mcp.tool(
+    name="list_documentation",
+    description="List all available documentation files and their paths."
+)
+def list_documentation() -> list[dict[str, str]]:
+    """List all available documentation files"""
+    docs = []
+    for file_path in sorted(DOCS_DIR.rglob("*.md")):
         relative_path = file_path.relative_to(DOCS_DIR)
-        uri = f"{relative_path.as_posix()}"
-        
-        # Extract a friendly name from the filename
-        name = file_path.stem.replace("-", " ").replace("_", " ").title()
-        
-        resources.append(Resource(
-            uri=uri,
-            name=name,
-            description=f"Documentation: {name}",
-            mimeType="text/markdown"
-        ))
-    
-    return resources
+        docs.append({
+            "path": relative_path.as_posix(),
+            "name": file_path.stem.replace("-", " ").replace("_", " ").title(),
+            "description": f"Documentation: {file_path.stem.replace('-', ' ').replace('_', ' ').title()}"
+        })
+    return docs
 
-@mcp.resource("{path}")
-async def read_doc(path: str) -> str:
+@mcp.tool(
+    name="read_documentation",
+    description="Read the contents of a specific documentation file. Provide the path relative to the docs directory."
+)
+def read_documentation(path: str) -> str:
     """Read a specific documentation file"""
     file_path = DOCS_DIR / path
     
@@ -461,8 +457,13 @@ async def read_doc(path: str) -> str:
     else:
         raise ValueError(f"Documentation not found: {path}")
 
-@mcp.resource("file:///index")
-async def docs_index() -> str:
+# Note: these probably "should" be resources, but I can't figure out
+# how to get them to show up in Claude.
+@mcp.tool(
+    name="get_documentation_index",
+    description="Get an index of all available documentation with links to each file."
+)
+def get_documentation_index() -> str:
     """Get an index of all available documentation"""
     docs = []
     for file_path in sorted(DOCS_DIR.rglob("*.md")):

--- a/src/groundlight_mcp_server/server.py
+++ b/src/groundlight_mcp_server/server.py
@@ -419,6 +419,8 @@ def update_detector_escalation_type(
 # Documentation directory
 DOCS_DIR = Path("/opt/groundlight/docs/")
 
+# Note: these probably "should" be resources, but I can't figure out
+# how to get them to show up in Claude.
 @mcp.tool(
     name="list_documentation",
     description="List all available documentation files and their paths."
@@ -457,17 +459,3 @@ def read_documentation(path: str) -> str:
     else:
         raise ValueError(f"Documentation not found: {path}")
 
-# Note: these probably "should" be resources, but I can't figure out
-# how to get them to show up in Claude.
-@mcp.tool(
-    name="get_documentation_index",
-    description="Get an index of all available documentation with links to each file."
-)
-def get_documentation_index() -> str:
-    """Get an index of all available documentation"""
-    docs = []
-    for file_path in sorted(DOCS_DIR.rglob("*.md")):
-        relative_path = file_path.relative_to(DOCS_DIR)
-        docs.append(f"- [{file_path.stem}]({relative_path.as_posix()})")
-
-    return "# Groundlight Documentation Index\n\n" + "\n".join(docs)


### PR DESCRIPTION
I tried to get this to work with MCP Resources, but nothing I tried was visible to Claude.  This is kinda dumb and slow but works - tool methods that list the SDK docs files, and let it read them one at a time.

It also includes an overview doc on "Building Groundlight Applications" which gives it general architectural and structural advice.
